### PR TITLE
UX: toggle for fullpage, merge for drawer

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -1,27 +1,44 @@
-.has-full-page-chat {
-  .sidebar-footer__mode-toggle {
-    display: flex;
-  }
-
-  .sidebar-wrapper {
-    &.chat-mode {
-      .sidebar-section:not([data-section-name="chat-channels"]):not(
+.sidebar-wrapper {
+  &.chat-mode {
+    .sidebar-section {
+      &:not([data-section-name="chat-channels"]):not(
           [data-section-name="chat-dms"]
         ) {
         display: none;
       }
     }
+    @if $toggle_mode == "double" {
+      .chat-mode-toggle {
+        background: var(--primary-low);
+        color: var(--primary-high);
+        .chat-channel-unread-indicator {
+          border: 2px solid var(--primary-low);
+        }
+      }
+    }
+  }
 
-    &.forum-mode {
-      .sidebar-section[data-section-name="chat-channels"],
-      .sidebar-section[data-section-name="chat-dms"] {
+  &.forum-mode {
+    .sidebar-section {
+      &[data-section-name="chat-channels"],
+      &[data-section-name="chat-dms"] {
         display: none;
       }
     }
 
-    .sidebar-sections {
-      padding-top: 1em;
+    @if $toggle_mode == "double" {
+      .forum-mode-toggle {
+        background: var(--primary-low);
+        color: var(--primary-high);
+        .chat-channel-unread-indicator {
+          border: 2px solid var(--primary-low);
+        }
+      }
     }
+  }
+
+  .sidebar-sections {
+    padding-top: 1em;
   }
 }
 
@@ -34,58 +51,65 @@
 }
 
 .sidebar-footer__mode-toggle {
-  display: none;
+  display: flex;
+
+  @if $toggle_position == "top" {
+    @if $toggle_mode == "double" {
+      border-bottom: 1px solid var(--primary-low);
+    }
+  } @else {
+    border-top: 1px solid var(--primary-low);
+  }
 
   a {
     display: flex;
     align-items: center;
-    padding: 0.5em;
+    padding: 0.75em;
     color: var(--primary-high);
     flex: 1 1 100%;
     justify-content: center;
-    position: relative;
 
     &:hover {
       background: var(--primary-low);
       color: var(--primary);
+      .chat-channel-unread-indicator {
+        border: 2px solid var(--primary-low);
+      }
     }
   }
-
   .chat-channel-unread-indicator {
+    margin-left: 2.5em;
+    margin-top: 1em;
     position: absolute;
-    right: -1em;
-    top: -1em;
-    width: 2em;
-    height: 2em;
-    border: 4px solid var(--primary-very-low);
+
+    width: 1em;
+    height: 1em;
+    border: 2px solid var(--primary-very-low);
     font-size: var(--font-down-5);
     z-index: 2;
-
     .number {
       display: none;
     }
   }
 }
 
-.sidebar-footer__mode-toggle {
-  padding: 0 1.3em;
-  margin: 1em 0;
-  border-top: none;
+@if $toggle_mode == "single" {
+  .sidebar-footer__mode-toggle {
+    margin: 1em 1.3em;
+    border-top: none;
 
-  @if $toggle_position == "top" {
-    margin: 1em 0 0;
-  }
+    @if $toggle_position == "top" {
+      margin: 0;
+    }
 
-  a {
-    background: var(--primary-low);
-
-    .d-icon {
-      margin-right: 0.33em;
+    .btn-default {
+      width: 100%;
     }
   }
 }
 
 @if $toggle_position == "bottom" {
+  // hide scroll fade for now
   .sidebar-footer-wrapper .sidebar-footer-container::before {
     display: none;
   }

--- a/javascripts/discourse/components/sidebar-mode-toggle.hbs
+++ b/javascripts/discourse/components/sidebar-mode-toggle.hbs
@@ -1,32 +1,30 @@
 {{#unless this.site.mobileView}}
-  <div class="sidebar-footer__mode-toggle" {{did-insert this.setDefaultMode}}>
-    <a
-      class="chat-mode-toggle"
-      {{on "click" this.toggleMode}}
-      data-sidebar-mode={{if (eq this.currentMode "forum") "chat" "forum"}}
-    >
-      {{#if (eq this.currentMode "chat")}}
-        {{#if (theme-setting "back_mode")}}
-          {{d-icon "arrow-left"}}
-          Back
-        {{else}}
-          {{d-icon "random"}}
-          Forum
-        {{/if}}
-      {{else}}
-        {{d-icon "random"}}
-        Chat
-      {{/if}}
+  {{#if (and this.currentUser this.currentMode)}}
+    <div class="sidebar-footer__mode-toggle">
 
-      {{#unless this.currentUserInDnD}}
-        {{#if (eq this.currentMode "forum")}}
-          <ChatHeaderIconUnreadIndicator />
-        {{else}}
-          {{#if this.unreadTopicCount}}
-            <div class="chat-channel-unread-indicator"></div>
-          {{/if}}
-        {{/if}}
-      {{/unless}}
-    </a>
-  </div>
+      {{#if (eq (theme-setting "toggle_mode") "single")}}
+        <DButton
+          @action={{action "toggleMode"}}
+          @class="btn-default chat-mode-toggle"
+          @icon="random"
+          @translatedLabel={{if (eq this.currentMode "chat") "Forum" "Chat"}}
+        />
+      {{else}}
+
+        <a
+          class="forum-mode-toggle"
+          {{on "click" this.toggleMode}}
+          data-sidebar-mode="forum"
+        >{{d-icon "university"}}</a>
+        <a
+          class="chat-mode-toggle"
+          {{on "click" this.toggleMode}}
+          data-sidebar-mode="chat"
+        >
+          {{d-icon "d-chat"}}
+        </a>
+
+      {{/if}}
+    </div>
+  {{/if}}
 {{/unless}}

--- a/javascripts/discourse/components/sidebar-mode-toggle.js
+++ b/javascripts/discourse/components/sidebar-mode-toggle.js
@@ -2,81 +2,81 @@ import Component from "@glimmer/component";
 import { action } from "@ember/object";
 import { inject as service } from "@ember/service";
 import { tracked } from "@glimmer/tracking";
-import { next } from "@ember/runloop";
 
 export default class SidebarModeToggle extends Component {
   @service currentUser;
   @service chatStateManager;
   @service site;
   @service router;
-  @service topicTrackingState;
 
-  @tracked unreadTopicCount;
   @tracked currentMode;
+  @tracked hideToggle = this.chatStateManager.isDrawerPreferred;
 
   constructor() {
     super(...arguments);
+    this.setDefaultMode();
     this.router.on("routeWillChange", (transition) => {
       this.updateModeBasedOnRoute(transition.to);
     });
-
-    this.callbackId = this.topicTrackingState.onStateChange(() => {
-      this.updateUnreadTopicCount();
-    });
-  }
-
-  willDestroy() {
-    this.topicTrackingState.offStateChange(this.callbackId);
-  }
-
-  get currentUserInDnD() {
-    return this.currentUser.isInDoNotDisturb();
-  }
-
-  @action
-  updateUnreadTopicCount() {
-    this.unreadTopicCount = this.topicTrackingState.countUnread();
   }
 
   updateModeBasedOnRoute(routeName) {
     if (routeName.name.startsWith("chat.")) {
-      this.updateSidebarWrapper("chat");
+      this.setChatMode();
     } else {
-      document
-        .querySelector(".sidebar-wrapper")
-        .classList.remove(this.currentMode + "-mode");
+      if (!this.chatStateManager.isDrawerPreferred) {
+        this.setForumMode();
+      } else {
+        this.removeMode();
+      }
     }
   }
 
-  updateSidebarWrapper(newMode) {
+  removeMode() {
     const sidebarWrapper = document.querySelector(".sidebar-wrapper");
-    sidebarWrapper.classList.remove(this.currentMode + "-mode");
-    sidebarWrapper.classList.add(newMode + "-mode");
-    next(() => {
-      this.currentMode = newMode;
-    });
+    sidebarWrapper.classList.remove("chat-mode");
+    sidebarWrapper.classList.remove("forum-mode");
+
+    this.currentMode = null;
+  }
+
+  setChatMode() {
+    const sidebarWrapper = document.querySelector(".sidebar-wrapper");
+    sidebarWrapper.classList.add("chat-mode");
+    sidebarWrapper.classList.remove("forum-mode");
+
+    this.currentMode = "chat";
+  }
+
+  setForumMode() {
+    const sidebarWrapper = document.querySelector(".sidebar-wrapper");
+    sidebarWrapper.classList.add("forum-mode");
+    sidebarWrapper.classList.remove("chat-mode");
+
+    this.currentMode = "forum";
   }
 
   @action
   setDefaultMode() {
-    const isChatRoute = this.router.currentURL.startsWith("/chat/");
-    const defaultMode = isChatRoute ? "chat" : "forum";
-    this.updateSidebarWrapper(defaultMode);
+    if (this.chatStateManager.isDrawerPreferred) {
+      return (this.currentMode = null);
+    }
+
+    if (this.router.currentURL.startsWith("/chat/")) {
+      this.setChatMode();
+    } else {
+      this.setForumMode();
+    }
   }
 
   @action
   toggleMode() {
     if (this.currentMode === "chat") {
-      this.updateSidebarWrapper("forum");
-      if (settings.back_mode) {
-        this.router.transitionTo(
-          this.chatStateManager.lastKnownAppURL.includes("/chat/")
-            ? "/latest"
-            : this.chatStateManager.lastKnownAppURL
-        );
-      }
-    } else {
-      this.updateSidebarWrapper("chat");
+      this.setForumMode();
+      this.router.transitionTo(this.chatStateManager.lastKnownAppURL);
+    } else if (this.currentMode === "forum") {
+      this.setChatMode();
+      this.router.transitionTo(this.chatStateManager.lastKnownChatURL);
     }
   }
 }

--- a/settings.yml
+++ b/settings.yml
@@ -10,5 +10,9 @@ toggle_position:
     - "top"
     - "bottom"
 
-back_mode:
-  default: false
+toggle_mode:
+  default: "single"
+  type: enum
+  choices:
+    - "single"
+    - "double"


### PR DESCRIPTION
Some changes from /t/70252/89:

* If I prefer full-screen, always show the toggle and isolate chat/forum sidebars
* Toggling to chat brings me to chat, toggling to forum brings me to the forum
* If I switch to drawer, always show the mixed sidebar
* Drop the activity notification dots


