### PR TITLE
UX: add custom header toggle

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -114,3 +114,35 @@
     display: none;
   }
 }
+
+// hide default chat header toggle on desktop
+.desktop-view {
+  .chat-header-icon {
+    display: none;
+  }
+}
+
+// hide custom chat header toggle on mobile
+.mobile-view {
+  .custom-chat-header-icon {
+    display: none;
+  }
+}
+
+// custom chat header toggle notification styles
+.header-dropdown-toggle.custom-chat-header-icon {
+  .icon {
+    .chat-channel-unread-indicator {
+      border: 2px solid var(--header_background);
+      position: absolute;
+      right: 2px;
+      bottom: 2px;
+      transition: border-color linear 0.15s;
+    }
+  }
+  &:hover {
+    .icon .chat-channel-unread-indicator {
+      border: 2px solid var(--primary-low);
+    }
+  }
+}

--- a/javascripts/discourse/components/custom-chat-header-icon.hbs
+++ b/javascripts/discourse/components/custom-chat-header-icon.hbs
@@ -1,0 +1,16 @@
+<a
+  {{on "click" this.toggleChatState}}
+  tabindex="0"
+  class={{concat-class "icon btn-flat" (if this.isActive "active")}}
+>
+
+  {{#if this.chatStateManager.isFullPageActive}}
+    {{d-icon "random"}}
+  {{else}}
+    {{d-icon "d-chat"}}
+  {{/if}}
+
+  {{#unless (or this.currentUserInDnD this.chatStateManager.isFullPageActive)}}
+    <ChatHeaderIconUnreadIndicator />
+  {{/unless}}
+</a>

--- a/javascripts/discourse/components/custom-chat-header-icon.js
+++ b/javascripts/discourse/components/custom-chat-header-icon.js
@@ -1,0 +1,49 @@
+import { inject as service } from "@ember/service";
+import Component from "@glimmer/component";
+import { action } from "@ember/object";
+
+export default class CustomChatHeaderIcon extends Component {
+  @service currentUser;
+  @service chatStateManager;
+  @service site;
+  @service router;
+  @service appEvents;
+
+  get currentUserInDnD() {
+    return this.currentUser.isInDoNotDisturb();
+  }
+
+  get isActive() {
+    return (
+      this.chatStateManager.isFullPageActive ||
+      this.chatStateManager.isDrawerActive
+    );
+  }
+
+  @action
+  toggleChatState() {
+    if (this.chatStateManager.isFullPageActive) {
+      // if we're in full page mode, switch to the last known forum URL
+      this.router.transitionTo(this.chatStateManager.lastKnownAppURL);
+    } else if (this.chatStateManager.isDrawerActive) {
+      // if we're in the drawer, close the drawer
+      this.chatStateManager.didToggleDrawer();
+      this.appEvents.trigger(
+        "chat:toggle-close",
+        this.chatStateManager.isDrawerActive
+      );
+    } else {
+      // if we're not in full page mode...
+      if (this.chatStateManager.isDrawerPreferred) {
+        // ...if we prefer the drawer, open the drawer
+        this.appEvents.trigger(
+          "chat:open-url",
+          this.chatStateManager.lastKnownChatURL
+        );
+      } else {
+        // ...if we don't prefer the drawer, switch to the last known forum URL
+        this.router.transitionTo(this.chatStateManager.lastKnownChatURL);
+      }
+    }
+  }
+}

--- a/javascripts/discourse/components/sidebar-mode-toggle.hbs
+++ b/javascripts/discourse/components/sidebar-mode-toggle.hbs
@@ -6,7 +6,7 @@
         <DButton
           @action={{action "toggleMode"}}
           @class="btn-default chat-mode-toggle"
-          @icon="random"
+          @icon={{if (eq this.currentMode "chat") "random" "d-chat"}}
           @translatedLabel={{if (eq this.currentMode "chat") "Forum" "Chat"}}
         />
       {{else}}

--- a/javascripts/discourse/initializers/initialize-custom-chat-header-icon.js
+++ b/javascripts/discourse/initializers/initialize-custom-chat-header-icon.js
@@ -1,0 +1,10 @@
+import { withPluginApi } from "discourse/lib/plugin-api";
+
+export default {
+  name: "custom-chat-header-icon",
+  initialize() {
+    withPluginApi("0.12.1", (api) => {
+      api.addToHeaderIcons("custom-chat-header-icon");
+    });
+  },
+};

--- a/javascripts/discourse/templates/components/sidebar.hbs
+++ b/javascripts/discourse/templates/components/sidebar.hbs
@@ -1,3 +1,4 @@
+<!-- adding plugin outlets here, not sure if we'll need it in core yet -->
 <DSection
   @pageClass="has-sidebar"
   @id="d-sidebar"

--- a/javascripts/discourse/widgets/custom-chat-header-icon.js
+++ b/javascripts/discourse/widgets/custom-chat-header-icon.js
@@ -1,0 +1,25 @@
+import { createWidget } from "discourse/widgets/widget";
+import RenderGlimmer from "discourse/widgets/render-glimmer";
+import { hbs } from "ember-cli-htmlbars";
+
+export default createWidget("custom-chat-header-icon", {
+  tagName: "li.header-dropdown-toggle.custom-chat-header-icon",
+  title: "chat.title_capitalized",
+  buildKey: () => `custom-chat-header-icon`,
+
+  services: ["chat"],
+
+  html() {
+    if (!this.chat.userCanChat) {
+      return;
+    }
+
+    return [
+      new RenderGlimmer(
+        this,
+        "div.widget-component-connector",
+        hbs`<CustomChatHeaderIcon />`
+      ),
+    ];
+  },
+});


### PR DESCRIPTION
Some changes from /t/70252/99

> 1. Allow header icon to toggle between chat and forum when chat is in full screen
> 2. Allow header icon to toggle drawer open/closed when not 
> 3. Use “chat icon” (d-chat) to in header and in sidebar toggle button for “go to chat”
> 4. Use “switcheroo icon” (random) in sidebar toggle and header for “go back to forum”

Rather than trying to override the existing chat header icon, I hide the default one with CSS and create a duplicate `custom-chat-header-icon` component... this will avoid clashing with any active chat work. 