### PR TITLE
FIX: Use `routeDidChange` event

### DIFF
--- a/javascripts/discourse/components/sidebar-mode-toggle.js
+++ b/javascripts/discourse/components/sidebar-mode-toggle.js
@@ -15,7 +15,7 @@ export default class SidebarModeToggle extends Component {
   constructor() {
     super(...arguments);
     this.setDefaultMode();
-    this.router.on("routeWillChange", (transition) => {
+    this.router.on("routeDidChange", (transition) => {
       this.updateModeBasedOnRoute(transition.to);
     });
   }


### PR DESCRIPTION
`routeWillChange` may fire for transitions which are later aborted (e.g. sidebar links to chat, which then open in the drawer). This can cause split-second flashes of UI, and mess with scrolling. `routeDidChange` does not have that issue, and also means that the UI changes happen in-sync with the rest of the page being refreshed.