### PR TITLE
FIX: update sidebar.hbs

### DIFF
--- a/javascripts/discourse/templates/components/sidebar.hbs
+++ b/javascripts/discourse/templates/components/sidebar.hbs
@@ -1,17 +1,30 @@
 <!-- adding plugin outlets here, not sure if we'll need it in core yet -->
-<DSection
-  @pageClass="has-sidebar"
-  @id="d-sidebar"
-  @class="sidebar-container"
-  @scrollTop={{false}}
->
+<DSection @pageClass="has-sidebar" @id="d-sidebar" @class="sidebar-container">
 
   <PluginOutlet @name="sidebar-above-sections" />
 
-  <Sidebar::Sections
-    @currentUser={{this.currentUser}}
-    @collapsableSections={{true}}
-  />
+  {{#if this.showMainPanel}}
+    <Sidebar::Sections
+      @currentUser={{this.currentUser}}
+      @collapsableSections={{true}}
+      @panel={{this.currentPanel}}
+    />
+  {{else}}
+    <Sidebar::ApiPanels
+      @currentUser={{this.currentUser}}
+      @collapsableSections={{true}}
+      @panel={{this.currentPanel}}
+    />
+  {{/if}}
+
+  {{#each this.switchPanelButtons as |button|}}
+    <DButton
+      @action={{action "switchPanel" button}}
+      @class="btn-default sidebar__panel-switch-button"
+      @icon={{button.switchButtonIcon}}
+      @translatedLabel={{button.switchButtonLabel}}
+    />
+  {{/each}}
 
   <PluginOutlet @name="sidebar-above-footer" />
 


### PR DESCRIPTION
This is a temporary solution. Component is including plugin outlets to `sidebar.hbs` by overwriting template. Template changed in core to:

https://github.com/discourse/discourse/blob/main/app/assets/javascripts/discourse/app/components/sidebar.hbs

In next iterations, full focus mode will use sidebar API instead overriding template.